### PR TITLE
docs: replace Coveralls badge with Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- ChangeMe: replace /multi-module-template in the badge urls below with the name of the repo-->
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Coverage Status](https://coveralls.io/repos/github/creek-service/multi-module-template/badge.svg?branch=main)](https://coveralls.io/github/creek-service/multi-module-template?branch=main)
+[![codecov](https://codecov.io/gh/creek-service/multi-module-template/branch/main/graph/badge.svg)](https://codecov.io/gh/creek-service/multi-module-template)
 [![build](https://github.com/creek-service/multi-module-template/actions/workflows/build.yml/badge.svg)](https://github.com/creek-service/multi-module-template/actions/workflows/build.yml)
 <!-- ChangeMe: replace 'multi-module-template-example' below with name of one published module in this repo -->
 [![Maven Central](https://img.shields.io/maven-central/v/org.creekservice/multi-module-template-example.svg)](https://central.sonatype.dev/search?q=multi-module-template-*)


### PR DESCRIPTION
## Summary

Replace the Coveralls.io coverage badge with the equivalent Codecov badge, following the migration from Coveralls to Codecov in https://github.com/creek-service/creek-release-test/pull/411.