### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-common-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-coverage-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-module-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-module-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-plugin-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/creek-sonatype-publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/creek-sonatype-publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@
   <!-- See https://checkstyle.org/config_header.html   -->
   <module name="RegexpHeader">
     <property name="header"
-            value="/\*\n\* Copyright (\d\d\d\d-)?2025 Creek Contributors \(https://github.com/creek-service\)$\n \*$\n \* Licensed under the Apache License, Version 2.0"/>
+            value="/\*\n\* Copyright (\d\d\d\d-)?2026 Creek Contributors \(https://github.com/creek-service\)$\n \*$\n \* Licensed under the Apache License, Version 2.0"/>
   </module>
 
   <module name="TreeWalker">

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/src/main/java/org/creekservice/api/example/Example.java
+++ b/example/src/main/java/org/creekservice/api/example/Example.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/src/main/java/org/creekservice/internal/example/ExampleImpl.java
+++ b/example/src/main/java/org/creekservice/internal/example/ExampleImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/src/test/java/org/creekservice/ModuleTest.java
+++ b/example/src/test/java/org/creekservice/ModuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example/src/test/java/org/creekservice/internal/example/ExampleImplTest.java
+++ b/example/src/test/java/org/creekservice/internal/example/ExampleImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update checkstyle header rule and existing copyright headers from 2025 to 2026.